### PR TITLE
Add contextual blurb to notebook entries

### DIFF
--- a/src/components/NotebookArticleHeader.astro
+++ b/src/components/NotebookArticleHeader.astro
@@ -1,0 +1,22 @@
+---
+import ArticleHeader from './ArticleHeader.astro';
+
+export interface Props {
+  title: string;
+  author: string;
+  publishedDate: string;
+}
+
+const { title, author, publishedDate } = Astro.props;
+---
+
+<ArticleHeader
+  title={title}
+  author={author}
+  publishedDate={publishedDate}
+/>
+
+<!-- Lab Notebook Blurb -->
+<p class="mb-5 border px-4 py-2 rounded bg-gray-100 text-base text-gray-800 max-w-[65ch]">
+  We are building <a href="https://worksquared.ai" class="border-b-2 hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700" target="_blank" rel="noopener noreferrer">WorkSquared</a>, a source-available AI-native workspace to evolve human + computer collaboration. In order to build a truly novel product experience, we are rethinking the <a href="/notebook/ws-tech-foundations/" class="border-b-2 hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700">technical foundations</a> from the ground up. This <a href="/notebook" class="border-b-2 hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700">Lab Notebook</a> chronicles our explorations.
+</p>

--- a/src/layouts/NotebookLayout.astro
+++ b/src/layouts/NotebookLayout.astro
@@ -1,0 +1,130 @@
+---
+export interface Props {
+  title: string;
+  description?: string;
+  image?: string;
+  url?: string;
+}
+
+const { title, description, image, url } = Astro.props;
+const siteName = 'SocioTechnica';
+const currentPath = Astro.url.pathname;
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="generator" content={Astro.generator} />
+    
+    <title>{title === siteName ? title : `${title} | ${siteName}`}</title>
+    {description && <meta name="description" content={description} />}
+    
+    {/* Open Graph / Facebook */}
+    {url && (
+      <>
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={url} />
+        <meta property="og:title" content={title} />
+        {description && <meta property="og:description" content={description} />}
+        {image && <meta property="og:image" content={image} />}
+        <meta property="og:site_name" content={siteName} />
+      </>
+    )}
+    
+    {/* Twitter */}
+    {url && (
+      <>
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:url" content={url} />
+        <meta name="twitter:title" content={title} />
+        {description && <meta name="twitter:description" content={description} />}
+        {image && <meta name="twitter:image" content={image} />}
+      </>
+    )}
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <div class="flex-grow container mx-auto px-4 max-w-4xl">
+      <header class="mb-5 mt-5 text-left">
+        <nav>
+          <ul class="">
+            <li class="font-medium inline">
+              <a 
+                class:list={[
+                  "hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700",
+                  { 'font-bold': currentPath === '/' }
+                ]}
+                href="/"
+                >SocioTechnica</a
+              >
+            </li>
+            <li class="inline ml-5">
+              <a 
+                class:list={[
+                  "hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700",
+                  { 'font-bold': currentPath.startsWith('/notebook') }
+                ]}
+                href="/notebook"
+                >Lab Notes</a
+              >
+            </li>
+            <li class="inline ml-5">
+              <a 
+                class:list={[
+                  "hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700",
+                  { 'font-bold': currentPath === '/about' }
+                ]}
+                href="/about"
+                >About</a
+              >
+            </li>
+            <li class="inline ml-5">
+              <a
+                class:list={[
+                  "hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700",
+                  { 'font-bold': currentPath === '/work-with-us' }
+                ]}
+                href="/work-with-us">Work With Us</a
+              >
+            </li>
+          </ul>
+        </nav>
+      </header>
+
+      <main>
+        <slot />
+      </main>
+    </div>
+
+    <footer class="container mx-auto px-4 max-w-4xl mb-5 pt-5">
+      <div class="text-center">
+        <p class="text-center text-lg mb-3">
+          <img src="/bluesky-logo.png" alt="bluesky-logo" class="w-5 h-5 inline-block" />
+          Follow along at
+          <a
+            class="hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700"
+            href="https://bsky.app/profile/sociotechnica.org"
+          >@sociotechnica</a>.
+        </p>
+
+        <p class="text-center text-sm">
+          A <a
+            class="border-b-2 hover:border-b-2 hover:border-yellow-700 hover:text-yellow-700"
+            href="/about"
+          >
+            Danvers Fleury and Jess Martin</a
+          > project.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>
+
+<style is:global>
+  @import '../styles/global.css';
+</style>

--- a/src/pages/notebook/forward.mdx
+++ b/src/pages/notebook/forward.mdx
@@ -4,15 +4,15 @@ description: "An introduction to our lab notes."
 publishedDate: "2025-04-10"
 author: "Danvers Fleury"
 ---
-import Layout from "../../layouts/Layout.astro";
-import ArticleHeader from "../../components/ArticleHeader.astro";
+import NotebookLayout from "../../layouts/NotebookLayout.astro";
+import NotebookArticleHeader from "../../components/NotebookArticleHeader.astro";
 
-<Layout 
+<NotebookLayout 
   title={frontmatter.title}
   description={frontmatter.description}
 >
 
-<ArticleHeader
+<NotebookArticleHeader
   title={frontmatter.title}
   author={frontmatter.author}
   publishedDate={frontmatter.publishedDate}
@@ -40,4 +40,4 @@ That was _my_ reading experience. I wouldn't expect it to be _yours_. As Jess of
 
 </article>
 
-</Layout>
+</NotebookLayout>

--- a/src/pages/notebook/planning-a-collab.mdx
+++ b/src/pages/notebook/planning-a-collab.mdx
@@ -5,15 +5,15 @@ publishedDate: "2025-05-17"
 author: "Danvers Fleury"
 ---
 
-import Layout from "../../layouts/Layout.astro";
-import ArticleHeader from "../../components/ArticleHeader.astro";
+import NotebookLayout from "../../layouts/NotebookLayout.astro";
+import NotebookArticleHeader from "../../components/NotebookArticleHeader.astro";
 
-<Layout 
+<NotebookLayout 
   title={frontmatter.title}
   description={frontmatter.description}
 >
 
-<ArticleHeader
+<NotebookArticleHeader
   title={frontmatter.title}
   author={frontmatter.author}
   publishedDate={frontmatter.publishedDate}
@@ -341,4 +341,4 @@ That said, it's 1:45 and I need to get Jess review materials at 2pm &mdash; and 
 
 </article>
 
-</Layout>
+</NotebookLayout>

--- a/src/pages/notebook/ws-tech-foundations.mdx
+++ b/src/pages/notebook/ws-tech-foundations.mdx
@@ -5,15 +5,15 @@ author: Jess Martin
 description: "An introduction to the underlying architectural foundations of Work Squared, an AI-native environment for businesses and organizations."
 ---
 
-import Layout from "../../layouts/Layout.astro";
-import ArticleHeader from "../../components/ArticleHeader.astro";
+import NotebookLayout from "../../layouts/NotebookLayout.astro";
+import NotebookArticleHeader from "../../components/NotebookArticleHeader.astro";
 
-<Layout 
+<NotebookLayout 
   title={frontmatter.title}
   description={frontmatter.description}
 >
 
-<ArticleHeader
+<NotebookArticleHeader
   title={frontmatter.title}
   author={frontmatter.author}
   publishedDate={frontmatter.publishedDate}
@@ -75,4 +75,4 @@ Current chat with language models is limited in some key ways:
 
 </article>
 
-</Layout>
+</NotebookLayout>

--- a/src/pages/notebook/ws-ui-safari.mdx
+++ b/src/pages/notebook/ws-ui-safari.mdx
@@ -5,15 +5,15 @@ publishedDate: "2025-05-10"
 author: "Danvers Fleury"
 ---
 
-import Layout from "../../layouts/Layout.astro";
-import ArticleHeader from "../../components/ArticleHeader.astro";
+import NotebookLayout from "../../layouts/NotebookLayout.astro";
+import NotebookArticleHeader from "../../components/NotebookArticleHeader.astro";
 
-<Layout 
+<NotebookLayout 
   title={frontmatter.title}
   description={frontmatter.description}
 >
 
-<ArticleHeader
+<NotebookArticleHeader
   title={frontmatter.title}
   author={frontmatter.author}
   publishedDate={frontmatter.publishedDate}
@@ -170,4 +170,4 @@ Coding as building blocks: <a href="https://snap.berkeley.edu/" target="_blank" 
 
 </article>
 
-</Layout>
+</NotebookLayout>


### PR DESCRIPTION
## Summary
Adds an introductory blurb to all lab notebook entries that explains the WorkSquared project context and links to relevant technical foundations. This helps readers understand the broader mission behind each lab note without having to navigate to other pages first.

The blurb appears after the title/author/date section and uses consistent styling with the rest of the site.

![image](https://github.com/user-attachments/assets/a620c315-d3a7-4d9d-9f62-83ea501515fd)


## Test plan
- [ ] Verify blurb appears on all notebook entries after title/author/date
- [ ] Check that WorkSquared link opens in new tab
- [ ] Confirm styling matches site design language

🤖 Generated with [Claude Code](https://claude.ai/code)