### PR TITLE
Add tarball download link to Alexandria page

### DIFF
--- a/src/pages/alexandria/index.astro
+++ b/src/pages/alexandria/index.astro
@@ -13,7 +13,7 @@ const currentVersion = fs.readFileSync('public/alexandria/latest-version.txt', '
 >
   <div class="flex items-baseline justify-between mb-4">
     <h1 class="font-serif text-4xl">Alexandria</h1>
-    <span class="font-mono text-gray-500" style="font-size: 1.6rem;">v{currentVersion}</span>
+    <a href={`/alexandria/alexandria-v${currentVersion}.tar.gz`} class="font-mono text-gray-500 hover:text-yellow-700 underline decoration-2 underline-offset-2 transition-colors" style="font-size: 1.6rem;" download>v{currentVersion}</a>
   </div>
 
   <p class="mb-8 text-lg leading-relaxed">


### PR DESCRIPTION
## Summary
- Makes the version number (top-right) a download link to the current tarball (`alexandria-v{version}.tar.gz`)
- Underline + hover style consistent with rest of site

## Test plan
- [ ] Click version number on `/alexandria/` — should download the tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/sociotechnica-site/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
